### PR TITLE
Ventoy: Fixed a typo in chocolateybeforemodify.ps1

### DIFF
--- a/ventoy/tools/chocolateybeforemodify.ps1
+++ b/ventoy/tools/chocolateybeforemodify.ps1
@@ -1,1 +1,1 @@
-﻿AGet-Process Ventoy2Disk -ErrorAction SilentlyContinue | Stop-Process -ErrorAction Stop
+﻿Get-Process Ventoy2Disk -ErrorAction SilentlyContinue | Stop-Process -ErrorAction Stop


### PR DESCRIPTION
Fixed a typo in chocolateybeforemodify.ps1 that was causing an error to show during install/upgrade. Also, would fail to kill the process if Ventoy2Disk was running during upgrade.