### PR TITLE
nvm.install: Wait for nvm-setup.exe to finish

### DIFF
--- a/nvm.install/tools/ChocolateyInstall.ps1
+++ b/nvm.install/tools/ChocolateyInstall.ps1
@@ -24,4 +24,4 @@ Install-ChocolateyZipPackage @packageArgs
 New-Item -Path "$toolsDir\nvm-setup.exe.ignore" -ItemType File
 
 # Start installation process
-Start-Process "$toolsDir\nvm-setup.exe" -ArgumentList "/VERYSILENT /NOCIONS /DIR=$nvmPath"
+Start-Process "$toolsDir\nvm-setup.exe" -ArgumentList "/VERYSILENT /NOCIONS /DIR=$nvmPath" -Wait


### PR DESCRIPTION
The ChocolateyInstall.ps1 script is not waiting for the setup program to finish. This causes problem if you do `choco install` programmatically and need all the environment variables to be set right after installation.

To fix that, add the `-Wait` flag to the Start-Process command.